### PR TITLE
Fix application ID length in Eta Examples.

### DIFF
--- a/Cpp-C/Eta/Applications/Examples/Common/rsslLoginConsumer.c
+++ b/Cpp-C/Eta/Applications/Examples/Common/rsslLoginConsumer.c
@@ -112,7 +112,7 @@ void setAuthenticationExtended(char* authenticationExtended)
  */
 void setApplicationId(char* applicationId)
 {
-	snprintf(cmdLineApplicationId, 255, "%s", applicationId);
+	snprintf(cmdLineApplicationId, MAX_LOGIN_INFO_STRLEN, "%s", applicationId);
 }
 
 


### PR DESCRIPTION
The `setApplicationId()` function passes incorrect destination string length to the `snprintf()` function, which exceeds the size of the static application ID buffer.